### PR TITLE
CSS fix for Header Logo

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -104,7 +104,7 @@ p, ul, li, a, span, div {
 
 	@media (min-width:660px) {
 		.navbar-brand {
-			margin-left:-54px;
+			margin-left:4%;
 		}
 		.navbar-brand::after {
 			width:84px;


### PR DESCRIPTION
On displays of 660px width the logo gets pushed out of the screen.
This PR fixes this behavior.