### PR TITLE
Remove faulty dividers

### DIFF
--- a/_articles/de/MiData/Berechtigungskonzept.md
+++ b/_articles/de/MiData/Berechtigungskonzept.md
@@ -9,11 +9,11 @@ date: 25.03.2022
 ---
 
 ## Rollen
-Eine Person kann in der MiData verschiedene Rollen haben. Diese berechtigen die Person bei-spielsweise, etwas zu sehen, zu bearbeiten oder zu löschen. Rollen können ganz unterschiedli-che Effekte haben. Eine Person mit Rolle Wolf sieht zum Beispiel nur die Anlässe, Kurse und Lager in der eigenen Abteilung und einige Informationen der Einheit, jedoch keine Personen. Eine Person mit der Rolle Adressverwalter* in bei einer Abteilung hat aber Zugriff auf alle Mit-glieder innerhalb dieser Gruppe. Eine Person mit Rolle Abteilungsleiter* in kann zusätzlich noch den Bestand melden und freigeben.
+Eine Person kann in der MiData verschiedene Rollen haben. Diese berechtigen die Person beispielsweise, etwas zu sehen, zu bearbeiten oder zu löschen. Rollen können ganz unterschiedliche Effekte haben. Eine Person mit Rolle Wolf sieht zum Beispiel nur die Anlässe, Kurse und Lager in der eigenen Abteilung und einige Informationen der Einheit, jedoch keine Personen. Eine Person mit der Rolle Adressverwalter* in bei einer Abteilung hat aber Zugriff auf alle Mitglieder innerhalb dieser Gruppe. Eine Person mit Rolle Abteilungsleiter* in kann zusätzlich noch den Bestand melden und freigeben.
 
 Eine gute Einführung zum Thema Rollen findest du in der [Hitobito-Dokumentation](https://hitobito.readthedocs.io/de/latest/access_concept.html)
 
-Die Berechtigung eines Benutzers setzt sich aus der Rolle und der Organisationseinheit zu-sammen. Grundlage dafür ist also auch die Struktur, beziehungsweise die verschiedenen Ebe-nen der Pfadi. Eine Person kann eine oder mehrere Rollen in einer oder mehreren Organisati-onseinheiten haben. Die Berechtigung ist jeweils an die Rolle gebunden. Dies bedeutet, dass eine Person mit einer neuen Rolle eine zusätzliche Berechtigung erhält. Wird diese Rolle wieder entfernt, wird auch die Berechtigung entfernt.
+Die Berechtigung eines Benutzers setzt sich aus der Rolle und der Organisationseinheit zusammen. Grundlage dafür ist also auch die Struktur, beziehungsweise die verschiedenen Ebenen der Pfadi. Eine Person kann eine oder mehrere Rollen in einer oder mehreren Organisationseinheiten haben. Die Berechtigung ist jeweils an die Rolle gebunden. Dies bedeutet, dass eine Person mit einer neuen Rolle eine zusätzliche Berechtigung erhält. Wird diese Rolle wieder entfernt, wird auch die Berechtigung entfernt.
 
 <img src="/images/documentation/rollen_berechtigungskonzept.png" width="50%" alt="Rollen Berechtigungskonzept"/>
 
@@ -22,30 +22,30 @@ Ein Layer entspricht einer hierarchischen Schicht und enthält die jeweiligen Gr
 
 <img src="/images/documentation/layer_berechtigungskonzept.png" width="50%" alt="Layer Berechtigungskonzept"/>
 
-Die erlangte Berechtigung bezieht sich immer auf die darunter liegende Organisation (in der Abbildung als Dreieck dargestellt). Wenn die Rolle schreibrechte hat, können die Daten verän-dert werden, bei Leserechten nur gelesen. Welche Person was sieht respektive bearbeiten kann, setzt sich aus der Rolle und der Berechtigungsrolle zusammen.
+Die erlangte Berechtigung bezieht sich immer auf die darunter liegende Organisation (in der Abbildung als Dreieck dargestellt). Wenn die Rolle schreibrechte hat, können die Daten verändert werden, bei Leserechten nur gelesen. Welche Person was sieht respektive bearbeiten kann, setzt sich aus der Rolle und der Berechtigungsrolle zusammen.
 
 #### Ausnahme Biber, Wolf, Pfadi, Pio und Rover
-Personen mit den Rollen (Biber, Wolf, Pfadi, Pio und Rover) werden nur für die Personen, die in den entsprechenden Abteilungen eine Rolle haben, angezeigt. Personen aus höheren Ebenen (z.b. Kantonsleiter) sehen direkt in der Mitgliederdatenbank keine Daten von den Teilnehmen-den. Bei einem Versand über ein Abo können diese Personen aber trotzdem erreicht werden.
+Personen mit den Rollen (Biber, Wolf, Pfadi, Pio und Rover) werden nur für die Personen, die in den entsprechenden Abteilungen eine Rolle haben, angezeigt. Personen aus höheren Ebenen (z.b. Kantonsleiter) sehen direkt in der Mitgliederdatenbank keine Daten von den Teilnehmenden. Bei einem Versand über ein Abo können diese Personen aber trotzdem erreicht werden.
 
 ## Berechtigungsstufen 
-Eine Berechtigungsstufe definiert den Zugriff im System, welche Daten gelesen und geschrie-ben werden dürfen. Jede Rolle hat eine oder mehrere Berechtigungsstufen.
+Eine Berechtigungsstufe definiert den Zugriff im System, welche Daten gelesen und geschrieben werden dürfen. Jede Rolle hat eine oder mehrere Berechtigungsstufen.
 
 #### Für Gruppen in der Struktur
-* admin: Administration von applikationsweiten Einstellungen wie Kursarten oder Etikettenforma-te.
-* layer_and_below_full: Alles Lesen und Schreiben auf dieser Ebene und allen darunter liegen-den Ebenen. Erstellen von Anlässen und Abos (Mailinglisten) auf dieser Ebene.
+* admin: Administration von applikationsweiten Einstellungen wie Kursarten oder Etikettenformate.
+* layer_and_below_full: Alles Lesen und Schreiben auf dieser Ebene und allen darunter liegenden Ebenen. Erstellen von Anlässen und Abos (Mailinglisten) auf dieser Ebene.
 * layer_and_below_read: Alles Lesen auf dieser Ebene und allen darunter liegenden Ebenen.
 * layer_full: Alles Lesen und Schreiben auf dieser Ebene. Erstellen von Anlässen und Abos (Mailinglisten) auf dieser Ebene.
 * layer_read: Alles Lesen auf dieser Ebene.
 * group_and_below_full: Lesen und Schreiben auf dieser und allen darunter liegenden Gruppen (ohne Ebenen). Inkl. Erstellen von Anlässen und Abos (Mailinglisten).
 * group_and_below_read: Lesen auf dieser und allen darunter liegenden Gruppen (ohne Ebenen).
-* group_full: Lesen und Schreiben nur auf dieser Gruppe. Erstellen von Anlässen und Abos (Mailing-listen) auf der Gruppe.
+* group_full: Lesen und Schreiben nur auf dieser Gruppe. Erstellen von Anlässen und Abos (Mailinglisten) auf der Gruppe.
 * group_read: Lesen nur auf dieser Gruppe.
 * contact_data: Lesen der Kontaktdaten aller anderen Personen mit Kontaktdatenberechtigung.
 * approve_applications: Bestätigen der Kursanmeldungen für Personen dieser Ebene.
 
 #### Für Events, Lager und Kurse
 * event_full: Darf den Anlass bearbeiten.
-* participations_full: Sieht alle Informationen der Teilnehmenden und darf die Teilnahmedaten bear-beiten.
+* participations_full: Sieht alle Informationen der Teilnehmenden und darf die Teilnahmedaten bearbeiten.
 * participations_read: Sieht die öffentlichen Informationen der Teilnehmenden.
 * qualify: Darf den Teilnehmenden eines Kurses die definierten Qualifikationen vergeben.
 

--- a/_articles/de/MiData/Testumgebung und Weiterentwicklung.md
+++ b/_articles/de/MiData/Testumgebung und Weiterentwicklung.md
@@ -14,25 +14,25 @@ Siehe den Artikel im [F.A.Q.](https://docu.scout.ch/de/faq)
 
 ## Weiterentwicklung
 
-Damit die MiData den bestehenden und neuen Bedürfnissen gerecht werden kann und auch in Zukunft weiterverwendet wird, muss sie kontinuierlich weiterentwickelt werden. Die Weiterent-wicklung ist unabhängig vom Support aufgestellt. Die MiData wird als strategisches Element in der PBS geführt und hat einen fixen Bestandteil der IT-Strategie und ein entsprechendes Budget.
+Damit die MiData den bestehenden und neuen Bedürfnissen gerecht werden kann und auch in Zukunft weiterverwendet wird, muss sie kontinuierlich weiterentwickelt werden. Die Weiterentwicklung ist unabhängig vom Support aufgestellt. Die MiData wird als strategisches Element in der PBS geführt und hat einen fixen Bestandteil der IT-Strategie und ein entsprechendes Budget.
 
 Die MiData ist häufig auch von Entwicklungen durch andere Projekte mitbetroffen. Das Team MiData und der ProductOwner sorgen für eine gesamtheitliche und pragmatische Priorisierung der jeweils anstehenden Weiterentwicklungen.
 
-Damit die Priorisierung zu nützlichen Ergebnissen kommt, werden auch die PowerUser der Kantonalverbände und der grösseren Regionen involviert. Folgender Ablauf hilft dabei, die Be-dürfnisse der Benutzer* innen einschätzen zu können:
+Damit die Priorisierung zu nützlichen Ergebnissen kommt, werden auch die PowerUser der Kantonalverbände und der grösseren Regionen involviert. Folgender Ablauf hilft dabei, die Bedürfnisse der Benutzer* innen einschätzen zu können:
 
 1.	Die primären Ansprechpersonen für die Benutzer sind die PowerUser in den Kantonen oder allenfalls noch in den Regionen. Ideen und Wünsche der Anwender* innen werden von den PowerUsern gesammelt und via E-Mail an den Product-Owner eingegeben.
-2.	Der Product-Owner der PBS sammelt die Anregungen und bereitet diese falls notwen-dig auf. 
+2.	Der ProductOwner der PBS sammelt die Anregungen und bereitet diese falls notwendig auf. 
 3.	Das MiData-Team priorisiert und spezifiziert die Erweiterung, wobei die Anforderungen der Kantonalverbände berücksichtigt werden.
 4.	Die priorisierten Erweiterungen werden mit dem Softwaredienstleister umgesetzt.
 
 Neben dem definierten Ablauf der PBS können auch noch andere Inputs an die IT-Kommission gelangen. Diese sind: 
 *	Die Bundesebene der PBS - Kommissionen, Projektgruppen, die Organe der PBS und die Geschäftsstelle haben die Möglichkeit, Wünsche und aktuelle Entwicklungen beim ProductOwner zu deponieren
 
-*	Commit auf GitHub – Hitobito ist eine Opensource Lösung welche auf GitHub verfügbar ist. Dies erlaubt es anderen Entwicklern Anpassungen oder Erweiterungen vorzunehmen. Diese werden mit einem „Pull Request“ beantragt. Die PBS gibt eine fachliche Einschätzung zum Pull Request ab, wenn nötig in Absprache mit den betroffenen Kommissionen. Die Verant-wortung über die Applikation hat die Firma Puzzle. Diese entscheidet, welche Pull Re-quest aufgenommen werden und kann Nachbesserungen einfordern. 
+*	Commit auf GitHub – Hitobito ist eine Opensource Lösung welche auf GitHub verfügbar ist. Dies erlaubt es anderen Entwicklern Anpassungen oder Erweiterungen vorzunehmen. Diese werden mit einem „Pull Request“ beantragt. Die PBS gibt eine fachliche Einschätzung zum Pull Request ab, wenn nötig in Absprache mit den betroffenen Kommissionen. Die Verantwortung über die Applikation hat die Firma Puzzle. Diese entscheidet, welche Pull Request aufgenommen werden und kann Nachbesserungen einfordern. 
 
-*	Community – Rund um die Opensource Lösung Hitobito hat sich eine Community gebildet. Im Mo-ment sind gegen 20 Organisationen in der Community vertreten. Eine jeweils aktuelle Liste findest du unter https://github.com/hitobito/hitobito#community. Aus dieser Runde kommen auch neue Entwicklungen, welche einen direkten Einfluss auf die MiDa-ta haben. Die Community ist ein guter Pool um sich auszutauschen und gemeinsam Ideen weiter zu treiben und ggf. auch gemeinsam zu finanzieren.
+*	Community – Rund um die Opensource Lösung Hitobito hat sich eine Community gebildet. Im Moment sind gegen 20 Organisationen in der Community vertreten. Eine jeweils aktuelle Liste findest du unter https://github.com/hitobito/hitobito#community. Aus dieser Runde kommen auch neue Entwicklungen, welche einen direkten Einfluss auf die MiData haben. Die Community ist ein guter Pool um sich auszutauschen und gemeinsam Ideen weiter zu treiben und ggf. auch gemeinsam zu finanzieren.
 
-*	Puzzle – Auch aus eigenem Interesse kann Puzzle Anpassungen oder Erweiterungen an hitobito vornehmen. Dies können auch systemtechnische Anpassungen, Aktualisierung von Komponenten oder Sicherheitsupdates sein, welche keinen direkten Einfluss für den Benutzer haben. Grössere Anpassungen werden mit der PBS abgestimmt, bei kleine-ren Anpassungen kann auch eine Information ausreichen. 
+*	Puzzle – Auch aus eigenem Interesse kann Puzzle Anpassungen oder Erweiterungen an hitobito vornehmen. Dies können auch systemtechnische Anpassungen, Aktualisierung von Komponenten oder Sicherheitsupdates sein, welche keinen direkten Einfluss für den Benutzer haben. Grössere Anpassungen werden mit der PBS abgestimmt, bei kleineren Anpassungen kann auch eine Information ausreichen. 
 
 
 ## Informationen zu MiData-Updates

--- a/_articles/de/MiData/Zweck, Ziel, Vorteile der Midata.md
+++ b/_articles/de/MiData/Zweck, Ziel, Vorteile der Midata.md
@@ -8,7 +8,7 @@ lang: de
 date: 25.03.2023
 ---
 
-Ziel und Zweck der Mitgliederdatenbank (MiData) ist, allen Ebenen der Pfadi – also Abteilungen, Regionen, Kantonalverbände und Bundesebene - eine Mitgliederverwaltung zu ermöglichen. Neben der Verwaltung von Mitgliederdaten bietet die MiData eine breite Palette an weiteren Funktionen. Sie ist eine angepasste Version der Applikation «hitobito», welche von diversen Verbänden in der Schweiz und in Deutschland eingesetzt wird. Wir sehen die Mitgliederdaten-bank als Werkzeug, dass verschiedene Pfadi-Prozesse unterstützt.
+Ziel und Zweck der Mitgliederdatenbank (MiData) ist, allen Ebenen der Pfadi – also Abteilungen, Regionen, Kantonalverbände und Bundesebene - eine Mitgliederverwaltung zu ermöglichen. Neben der Verwaltung von Mitgliederdaten bietet die MiData eine breite Palette an weiteren Funktionen. Sie ist eine angepasste Version der Applikation «hitobito», welche von diversen Verbänden in der Schweiz und in Deutschland eingesetzt wird. Wir sehen die Mitgliederdatenbank als Werkzeug, dass verschiedene Pfadi-Prozesse unterstützt.
 
 Die Abteilungen verwalten ihre Abteilungsdaten selber. Die Datenhoheit, und damit auch die Verantwortung über diese Daten ist also dezentral organisiert. 
 

--- a/_articles/fr/MiData/Concept d'autorisation.md
+++ b/_articles/fr/MiData/Concept d'autorisation.md
@@ -9,23 +9,23 @@ date: 25.03.2023
 ---
 
 ## Rôles
-Une personne peut avoir différents rôles dans MiData. Ces rôles autorisent par exemple la personne à voir, à modifier ou à supprimer quelque chose. Les rôles peuvent avoir des fonc-tions très différentes. Une personne ayant le rôle Louveteau·ette ne voit par exemple que les événements, les cours et les camps de son propre groupe et quelques informations de l'unité, mais pas les personnes. Une personne ayant le rôle de gestionnaire d'adresses dans un groupe a cependant accès à tous les membres de son groupe. Une personne ayant le rôle de responsable de groupe peut également signaler et valider le stock.
+Une personne peut avoir différents rôles dans MiData. Ces rôles autorisent par exemple la personne à voir, à modifier ou à supprimer quelque chose. Les rôles peuvent avoir des fonctions très différentes. Une personne ayant le rôle Louveteau·ette ne voit par exemple que les événements, les cours et les camps de son propre groupe et quelques informations de l'unité, mais pas les personnes. Une personne ayant le rôle de gestionnaire d'adresses dans un groupe a cependant accès à tous les membres de son groupe. Une personne ayant le rôle de responsable de groupe peut également signaler et valider le stock.
 
 Tu trouveras une bonne introduction au sujet des rôles dans la [Hitobito documentation](https://hitobito.readthedocs.io/fr/latest/access_concept.html).
 
-Les autorisations d'un·e utilisateur·trice se composent du rôle et d'une unité de l'organisation. La structure, respectivement les différents niveaux du scoutisme, constituent donc la base. Une personne peut avoir un ou plusieurs rôles dans une ou plusieurs unités d'une ou plusieurs or-ganisations. Les autorisations sont toujours liées au rôle. Cela signifie qu'une personne obtient des autorisations supplémentaires avec un nouveau rôle. Si ce rôle est supprimé, les autorisa-tions sont également supprimées.
+Les autorisations d'un·e utilisateur·trice se composent du rôle et d'une unité de l'organisation. La structure, respectivement les différents niveaux du scoutisme, constituent donc la base. Une personne peut avoir un ou plusieurs rôles dans une ou plusieurs unités d'une ou plusieurs organisations. Les autorisations sont toujours liées au rôle. Cela signifie qu'une personne obtient des autorisations supplémentaires avec un nouveau rôle. Si ce rôle est supprimé, les autorisations sont également supprimées.
 
 <img src="/images/documentation/rollen_berechtigungskonzept.png" width="50%" alt="rôles concept d'autorisation "/>
 
 #### Layer
-Un layer correspond à une couche hiérarchique et contient les groupes respectifs. Dans MiDa-ta, le MSdS, l'AC, la région (si elle existe) et le groupe constituent chacun un layer. Dans l'illus-tration suivante, les layers sont mis en évidence en couleur.
+Un layer correspond à une couche hiérarchique et contient les groupes respectifs. Dans MiData, le MSdS, l'AC, la région (si elle existe) et le groupe constituent chacun un layer. Dans l'illustration suivante, les layers sont mis en évidence en couleur.
 
 <img src="/images/documentation/layer_berechtigungskonzept.png" width="50%" alt="Layer concept d'autorisation"/>
 
-Les autorisations accordées se basent toujours sur l'organisation subordonnée (représentée par un triangle dans l'illustration). Si le rôle a des droits d'écriture, les données peuvent être modifiées, s'il a des droits de lecture, elles peuvent uniquement être lues. Le rôle et les autori-sations déterminent quelle personne peut voir ou modifier les données.
+Les autorisations accordées se basent toujours sur l'organisation subordonnée (représentée par un triangle dans l'illustration). Si le rôle a des droits d'écriture, les données peuvent être modifiées, s'il a des droits de lecture, elles peuvent uniquement être lues. Le rôle et les autorisations déterminent quelle personne peut voir ou modifier les données.
 
 #### Exceptions : Castor, Louveteau·ette, Éclaireur·euse, Pico et Routier 
-Les personnes avec les rôles (Castor, Louveteau·ette, Éclaireur·euse, Pico et Routier) ne sont affichées que pour les personnes qui ont un rôle dans les groupes correspondants. Les per-sonnes des niveaux supérieurs (par ex. les responsables cantonaux·ales) ne voient pas les données des participant·e·s directement dans la base de données des membres. En cas d'en-voi via un abonnement, ces personnes peuvent tout de même être contactées.
+Les personnes avec les rôles (Castor, Louveteau·ette, Éclaireur·euse, Pico et Routier) ne sont affichées que pour les personnes qui ont un rôle dans les groupes correspondants. Les personnes des niveaux supérieurs (par ex. les responsables cantonaux·ales) ne voient pas les données des participant·e·s directement dans la base de données des membres. En cas d'envoi via un abonnement, ces personnes peuvent tout de même être contactées.
 
 
 ## Niveaux d'autorisation
@@ -37,9 +37,9 @@ Un niveau d'autorisation définit l'accès dans le système, quelles données pe
 * layer_and_below_read: Lecture à ce niveau et à tous les niveaux inférieurs.
 * layer_full: Lecture et écriture à ce niveau. Création d'événements et d'abonnements (listes de diffusion) à ce niveau.
 * layer_read: Lecture à ce niveau.
-* group_and_below_full: Lecture et écriture dans ce groupe et dans tous les groupes subor-donnés (sans niveaux). Y compris la création d'événements et d'abonnements (listes de diffu-sion).
-* group_and_below_read: Lecture et écriture dans ce groupe et dans tous les groupes subor-donnés (sans niveaux).
-* group_full: Lecture et écriture uniquement dans ce groupe. Création d'événements et d'abon-nements (listes de diffusion) dans ce groupe.
+* group_and_below_full: Lecture et écriture dans ce groupe et dans tous les groupes subordonnés (sans niveaux). Y compris la création d'événements et d'abonnements (listes de diffusion).
+* group_and_below_read: Lecture et écriture dans ce groupe et dans tous les groupes subordonnés (sans niveaux).
+* group_full: Lecture et écriture uniquement dans ce groupe. Création d'événements et d'abonnements (listes de diffusion) dans ce groupe.
 * group_read: Lecture uniquement dans ce groupe.
 * contact_data: Lecture des données de contact de toutes les autres personnes disposant d'une autorisation de contact.
 * approve_applications: Possibilité de confirmer les inscriptions aux cours pour les personnes de ce niveau.

--- a/_articles/fr/MiData/Environnement test et développement.md
+++ b/_articles/fr/MiData/Environnement test et développement.md
@@ -15,19 +15,19 @@ Voir l'article dans [F.A.Q.](https://docu.scout.ch/fr/faq)
 ## Développement
 
 Pour que MiData puisse répondre aux besoins actuels et nouveaux ainsi que continuer à être utilisé à l'avenir, il faut un développement continuel. Le développement est indépendant du support. MiData est géré comme un élément stratégique au sein du MSdS et fait partie inté-grante de la stratégie informatique, avec un budget correspondant.
-MiData est aussi souvent concernée par le développement d'autres projets. L'équipe MiData et le Product-Owner veillent à une priorisation globale et pragmatique des développements à venir.
+MiData est aussi souvent concernée par le développement d'autres projets. L'équipe MiData et le ProductOwner veillent à une priorisation globale et pragmatique des développements à venir.
 Pour que cette priorisation aboutisse à des résultats utiles, les PowerUser des associations cantonales et des grandes régions sont également impliqués. La procédure suivante permet d'évaluer les besoins des utilisateur·trice·s:
 
-1.	Les premières personnes de contact pour les utilisateurs sont les PowerUsers des can-tons ou, le cas échéant, des régions. Les idées et les souhaits des utilisateur·trice·s sont collectés par les PowerUsers et transmis par e-mail au Product-Owner.
-2.	Le Product-Owner du MSdS rassemble les suggestions et les traite si nécessaire. 
+1.	Les premières personnes de contact pour les utilisateurs sont les PowerUsers des cantons ou, le cas échéant, des régions. Les idées et les souhaits des utilisateur·trice·s sont collectés par les PowerUsers et transmis par e-mail au ProductOwner.
+2.	Le ProductOwner du MSdS rassemble les suggestions et les traite si nécessaire. 
 3.	L'équipe MiData définit les priorités et spécifie les améliorations en tenant compte des exigences des associations cantonales.
 4.	Les améliorations prioritaires sont mises en œuvre avec le fournisseur de logiciels.
 
 En plus du déroulement défini par le MSdS, d'autres contributions peuvent être transmises à l'équipe MiData. Il s'agit de :
 
-* Le niveau fédéral du MSdS - les commissions, les groupes de projet, les organes du MSdS et le secrétariat ont la possibilité de déposer des souhaits et des développe-ments actuels auprès du ProductOwner.
-* Commits sur GitHub - Hitobito est une solution open source qui est disponible sur Gi-tHub. Ceci permet à d'autres développeurs de procéder à des ajustements ou à des améliorations. Celles-ci sont soumises au moyen de "Pull Request". Le MSdS donne un avis technique sur la demande, si nécessaire en concertation avec les commissions concernées. La responsabilité de l'application incombe à l'entreprise Puzzle. Celle-ci décide quelles Pull Requests seront prises en compte et peut demander des améliora-tions.
-*	Communauté - Une communauté s'est formée autour de Opensource Hitobito. Actuel-lement, environ 20 organisations sont représentées dans la communauté. Tu trouveras une liste actualisée sur https://github.com/hitobito/hitobito#community.   C'est de ce cercle que proviennent les nouveaux développements qui ont une influence directe sur MiData. La communauté est un bon pool pour échanger des idées et les faire pro-gresser ensemble et, le cas échéant, pour les financer ensemble.
+* Le niveau fédéral du MSdS - les commissions, les groupes de projet, les organes du MSdS et le secrétariat ont la possibilité de déposer des souhaits et des développements actuels auprès du ProductOwner.
+* Commits sur GitHub - Hitobito est une solution open source qui est disponible sur GitHub. Ceci permet à d'autres développeurs de procéder à des ajustements ou à des améliorations. Cellesci sont soumises au moyen de "Pull Request". Le MSdS donne un avis technique sur la demande, si nécessaire en concertation avec les commissions concernées. La responsabilité de l'application incombe à l'entreprise Puzzle. Celle-ci décide quelles Pull Requests seront prises en compte et peut demander des améliorations.
+*	Communauté - Une communauté s'est formée autour de Opensource Hitobito. Actuellement, environ 20 organisations sont représentées dans la communauté. Tu trouveras une liste actualisée sur https://github.com/hitobito/hitobito#community.   C'est de ce cercle que proviennent les nouveaux développements qui ont une influence directe sur MiData. La communauté est un bon pool pour échanger des idées et les faire progresser ensemble et, le cas échéant, pour les financer ensemble.
 *	Puzzle - Dans son propre intérêt, Puzzle peut également procéder à des adaptations ou à des améliorations de hitobito. Il peut s'agir d'adaptations techniques du système, de l'actualisation de composants ou de mises à jour de sécurité qui n'ont pas d'influence directe sur l'utilisateur·trice. Les adaptations importantes sont coordonnées avec le MSdS, pour les adaptations mineures, une notification peut suffire.
 *
 5.1	Informations sur les mises à jour de MiData

--- a/_articles/fr/MiData/Exploitation.md
+++ b/_articles/fr/MiData/Exploitation.md
@@ -30,7 +30,7 @@ Afin de garantir un fonctionnement régulier, les tâches à effectuer sont déf
 * Organisation et communication des releases, maintenances et pannes
 
 ## Équipe MiData ([midata@pbs.ch](mailto:midata@pbs.ch))  
-* Intégration des améliorations en collaboration avec les PowerUsers des AC - Confé-rence MiData
+* Intégration des améliorations en collaboration avec les PowerUsers des AC - Conférence MiData
 * Priorisation et spécification des améliorations en collaboration avec les PowerUsers des AC
 * Organisation de hackathons
 * Représentation dans la communauté Hitobito

--- a/_articles/fr/MiData/Support.md
+++ b/_articles/fr/MiData/Support.md
@@ -8,7 +8,7 @@ lang: fr
 date: 25.03.2023
 ---
 
-Le rôle d'un PowerUser peut être défini pour les groupes, les régions et les associations canto-nales. Ces PowerUser sont les interlocuteurs principaux des utilisateur·trice·s. Les utilisateur·trice·s peuvent trouver leurs PowerUsers respectifs sur la [page d'aide de MiData](https://db.scout.ch/fr/help).
+Le rôle d'un PowerUser peut être défini pour les groupes, les régions et les associations cantonales. Ces PowerUser sont les interlocuteurs principaux des utilisateur·trice·s. Les utilisateur·trice·s peuvent trouver leurs PowerUsers respectifs sur la [page d'aide de MiData](https://db.scout.ch/fr/help).
 
 Si les PowerUser cantonaux ont besoin d'une aide plus approfondie, ils peuvent s'adresser au MSdS (midata@pbs.ch,  0313280551).
 

--- a/_articles/it/MiData/Ambiente di test e ulteriori sviluppi .md
+++ b/_articles/it/MiData/Ambiente di test e ulteriori sviluppi .md
@@ -14,7 +14,7 @@ Vedi la voce in [F.A.Q.](https://docu.scout.ch/it/faq)
 
 ## ULTERIORI SVILUPPI
 
-Affinché MiData possa soddisfare le esigenze attuali e nuove, e continuare a essere utilizzato in futuro, è necessario svilupparlo continuamente. Ulteriori sviluppi vengono gestiti indipendente-mente dal supporto. MiData viene gestito come elemento strategico del MSS, ricopre un ruolo fisso nella strategia IT e dispone di un budget corrispondente.
+Affinché MiData possa soddisfare le esigenze attuali e nuove, e continuare a essere utilizzato in futuro, è necessario svilupparlo continuamente. Ulteriori sviluppi vengono gestiti indipendentemente dal supporto. MiData viene gestito come elemento strategico del MSS, ricopre un ruolo fisso nella strategia IT e dispone di un budget corrispondente.
 
 MiData è spesso influenzato dagli sviluppi di altri progetti. Il team MiData e il product owner assicurano una priorità olistica e pragmatica dei rispettivi aggiornamenti previsti. 
 
@@ -28,11 +28,11 @@ Affinché la definizione delle priorità produca risultati utili, saranno coinvo
 Oltre al processo definito dal MSS, il Team MiData può ricevere anche altri input. Questi sono:
 
 *	Il livello federale del MSS - le commissioni, i gruppi di progetto, gli organi del MSS e il segretariato hanno la possibilità di presentare al ProductOwner i propri desideri e gli aggiornamenti in corso.
-*	Commits su GitHub – Hitobito è una soluzione open source disponibile su GitHub. Ciò consente ad altri programmatori di apportare modifiche o aggiornamenti. Queste ven-gono richieste con una "pull request". Il MSS fornisce una valutazione tecnica della ri-chiesta di pull, se necessario in consultazione con le commissioni interessate. La socie-tà Puzzle è responsabile dell'applicazione. Decide quali richieste di pull devono essere incluse e può richiederne il miglioramento.
-*	Community – Attorno alla soluzione open source Hitobito si è formata una community, nella quale sono attualmente rappresentate circa 20 organizzazioni. Un elenco aggior-nato è disponibile all'indirizzo https://github.com/hitobito/hitobito#community.  An-che i nuovi aggiornamenti che hanno un'influenza diretta su MiData provengono da questa community. La community è un ottimo bacino per scambiare idee e portarle avanti insieme, e possibilmente anche finanziarle insieme. 
-*	Puzzle – Anche Puzzle può apportare modifiche o miglioramenti a hitobito nel proprio interesse. Può trattarsi anche di aggiornamenti tecnici del sistema, di update di compo-nenti o di aggiornamenti di sicurezza, che non hanno un'influenza diretta sull'utente. Gli adattamenti più grandi sono coordinati con il MSS; per gli aggiornamenti più piccoli può essere sufficiente anche una semplice informativa.
+*	Commits su GitHub – Hitobito è una soluzione open source disponibile su GitHub. Ciò consente ad altri programmatori di apportare modifiche o aggiornamenti. Queste vengono richieste con una "pull request". Il MSS fornisce una valutazione tecnica della richiesta di pull, se necessario in consultazione con le commissioni interessate. La società Puzzle è responsabile dell'applicazione. Decide quali richieste di pull devono essere incluse e può richiederne il miglioramento.
+*	Community – Attorno alla soluzione open source Hitobito si è formata una community, nella quale sono attualmente rappresentate circa 20 organizzazioni. Un elenco aggiornato è disponibile all'indirizzo https://github.com/hitobito/hitobito#community.  Anche i nuovi aggiornamenti che hanno un'influenza diretta su MiData provengono da questa community. La community è un ottimo bacino per scambiare idee e portarle avanti insieme, e possibilmente anche finanziarle insieme. 
+*	Puzzle – Anche Puzzle può apportare modifiche o miglioramenti a hitobito nel proprio interesse. Può trattarsi anche di aggiornamenti tecnici del sistema, di update di componenti o di aggiornamenti di sicurezza, che non hanno un'influenza diretta sull'utente. Gli adattamenti più grandi sono coordinati con il MSS; per gli aggiornamenti più piccoli può essere sufficiente anche una semplice informativa.
 
 ## Informazioni sugli aggiornamenti di MiData 
-Quando è previsto un aggiornamento, le associazioni cantonali e i/le responsabili delle commis-sioni del MSS ricevono una notifica. Le modalità di diffusione delle informazioni all'interno dell'associazione cantonale variano. Per ricevere gli aggiornamenti di MiData, è anche possibile iscriversi manualmente alla newsletter del MSS IT Tools. 
+Quando è previsto un aggiornamento, le associazioni cantonali e i/le responsabili delle commissioni del MSS ricevono una notifica. Le modalità di diffusione delle informazioni all'interno dell'associazione cantonale variano. Per ricevere gli aggiornamenti di MiData, è anche possibile iscriversi manualmente alla newsletter del MSS IT Tools. 
 
-Allo stesso modo, le informazioni di aggiornamento di MiData sono disponibili all'indirizzo pfa-di.swiss .    
+Allo stesso modo, le informazioni di aggiornamento di MiData sono disponibili all'indirizzo pfadi.swiss .    

--- a/_articles/it/MiData/Concetto di autorizzazione.md
+++ b/_articles/it/MiData/Concetto di autorizzazione.md
@@ -9,7 +9,7 @@ date: 25.03.2023
 ---
 
 ## Ruoli
-Una persona può ricoprire diversi ruoli in MiData. Questi autorizzano la persona, ad esempio, a vedere, modificare o cancellare determinati elementi. I ruoli possono avere effetti molto diversi. Ad esempio, una persona con il ruolo di Lupetto vede solo gli eventi, i corsi e i campi della pro-pria sezione e alcune informazioni sull'unità, ma non i dati delle altre persone. Una persona con il ruolo di responsabile della banca dati di una sezione, invece, ha accesso a tutti i membri del gruppo. Una persona con il ruolo di Capo sezione può anche avviare e confermare un censi-mento. 
+Una persona può ricoprire diversi ruoli in MiData. Questi autorizzano la persona, ad esempio, a vedere, modificare o cancellare determinati elementi. I ruoli possono avere effetti molto diversi. Ad esempio, una persona con il ruolo di Lupetto vede solo gli eventi, i corsi e i campi della propria sezione e alcune informazioni sull'unità, ma non i dati delle altre persone. Una persona con il ruolo di responsabile della banca dati di una sezione, invece, ha accesso a tutti i membri del gruppo. Una persona con il ruolo di Capo sezione può anche avviare e confermare un censimento. 
 
 Una buona introduzione al tema dei ruoli si trova nella [Documentazione di Hitobito](https://hitobito.readthedocs.io/it/latest/access_concept.html).
 
@@ -37,7 +37,7 @@ Un livello di autorizzazione definisce l'accesso al sistema, che permette di leg
 * layer_full: Può leggere e scrivere a questo livello. Può creare eventi e iscrizioni (mailing list) a questo livello.
 * layer_read: Può leggere a questo livello. 
 * group_and_below_full: Può leggere e scrivere su questo gruppo e tutti i gruppi inferiori (senza livelli). Può creare eventi e iscrizioni (mailing list)
-* group_and_below_read: Può leggere e scrivere su questo gruppo e tutti i gruppi inferiori (sen-za livelli).
+* group_and_below_read: Può leggere e scrivere su questo gruppo e tutti i gruppi inferiori (senza livelli).
 * group_full: Può leggere e scrivere su questo gruppo. Può creare eventi e iscrizioni (mailing list)
 * group_read: Può leggere solo in questo gruppo 
 * contact_data: Può leggere i dati di contatto di tutte le altre persone con autorizzazione ai dati di contatto

--- a/_articles/it/MiData/Funzionamento.md
+++ b/_articles/it/MiData/Funzionamento.md
@@ -29,7 +29,7 @@ Per garantire un funzionamento regolare, i compiti previsti sono ben definiti e 
 * Organizza e comunica aggiornamenti, manutenzioni e interruzioni di servizio
 
 ## Team MiData (midata@pbs.ch) 
-* Include evtl. estensioni in collaborazione con i PowerUser delle AC - Conferenza MiDa-ta
+* Include evtl. estensioni in collaborazione con i PowerUser delle AC - Conferenza MiData
 * Definisce le priorità e le specifiche delle integrazioni in collaborazione con i PowerUsers delle AC.
 * Organizza i Hackathon
 * Rappresenta Midata all’interno della comunità Hitobito

--- a/_articles/it/MiData/Supporto.md
+++ b/_articles/it/MiData/Supporto.md
@@ -8,7 +8,7 @@ lang: it
 date: 25.03.2023
 ---
 
-Il ruolo di PowerUser può essere definito a livello sezionale, regionale e cantonale. Questi Po-werUser sono i contatti principali per gli utenti. Gli utenti possono trovare i rispettivi PowerUser nella pagina di aiuto di MiData.
+Il ruolo di PowerUser può essere definito a livello sezionale, regionale e cantonale. Questi PowerUser sono i contatti principali per gli utenti. Gli utenti possono trovare i rispettivi PowerUser nella pagina di aiuto di MiData.
 
 Se i PowerUser cantonali hanno bisogno di ulteriore aiuto, possono contattare il MSS (midata@pbs.ch, 0313280551). 
 

--- a/_articles/it/MiData/Zweck, Ziel, Vorteile der Midata.md
+++ b/_articles/it/MiData/Zweck, Ziel, Vorteile der Midata.md
@@ -9,9 +9,9 @@ date: 05.03.2023
 ---
 L'obiettivo e lo scopo della banca dati dei membri (MiData) è quello di consentire un'adeguata gestione dei membri a tutti i livelli dello scoutismo, ovvero le sezioni, le zone, le associazioni cantonali e il livello federale. Oltre alla gestione dei dati dei membri, MiData offre un'ampia gamma di altre funzioni. Si tratta infatti di una versione adattata dell'applicazione "hitobito", utilizzata da diverse associazioni in Svizzera e in Germania. Consideriamo la banca dati dei membri come strumento di supporto a vari processi scout.  
 
-Le sezioni gestiscono autonomamente i propri dati sezionali. La sovranità dei dati, e di conse-guenza anche la loro responsabilità, è quindi organizzata in modo decentrato.  
+Le sezioni gestiscono autonomamente i propri dati sezionali. La sovranità dei dati, e di conseguenza anche la loro responsabilità, è quindi organizzata in modo decentrato.  
 
-La protezione dei dati dei nostri membri ci sta particolarmente a cuore. La [nuova legge sulla protezione dei dati (nLPD)](https://www.kmu.admin.ch/kmu/it/home/fatti-e-tendenze/digitalizzazione/protezione-dei-dati/nuova-legge-sulla-protezione-dei-dati-nlpd.html) e la [direttiva sulla privacy del MSS](https://pfadi.swiss/it/associazione/protezione-dei-dati/isp/) vanno rigorosamente rispet-tate. 
+La protezione dei dati dei nostri membri ci sta particolarmente a cuore. La [nuova legge sulla protezione dei dati (nLPD)](https://www.kmu.admin.ch/kmu/it/home/fatti-e-tendenze/digitalizzazione/protezione-dei-dati/nuova-legge-sulla-protezione-dei-dati-nlpd.html) e la [direttiva sulla privacy del MSS](https://pfadi.swiss/it/associazione/protezione-dei-dati/isp/) vanno rigorosamente rispettate. 
 
 
 ## Quali sono i vantaggi di una banca dati membri unica? 


### PR DESCRIPTION
Trennzeichen entfernen, die beim Kopieren aus Word mitgekommen sind.