### PR TITLE
chore: remove archive hint and link due to release notes are no longe…

### DIFF
--- a/de/versionshinweise.html
+++ b/de/versionshinweise.html
@@ -19,8 +19,3 @@ lang: de
 		{% endfor %}
 	</ul>
 {% endfor %}
-
-<h3>Archiv</h3>
-
-<p>Ältere ReleaseNotes findest du im <a href="https://pfadi.swiss/de/publikationen-downloads/downloads/?search=Release&c=7&c=87&page=1" target="_blank">Downloadbereich von pfadi.swiss</a>.</p>
-

--- a/fr/notes-de-version.html
+++ b/fr/notes-de-version.html
@@ -19,7 +19,3 @@ lang: fr
 		{% endfor %}
 	</ul>
 {% endfor %}
-
-<h3>Archive</h3>
-
-<p>Tu trouveras des ReleaseNotes plus anciennes dans <a href="https://pfadi.swiss/fr/publications-telechargements/downloads/?search=Release&c=7&c=87" target="_blank">l'espace de téléchargement de pfadi.swiss</a>.</p>

--- a/it/note-di-rilascio.html
+++ b/it/note-di-rilascio.html
@@ -19,8 +19,3 @@ lang: it
 		{% endfor %}
 	</ul>
 {% endfor %}
-
-<h3>Archivio</h3>
-
-<p>Le ReleaseNotes precedenti si trovano alla pagina <a href="https://pfadi.swiss/it/pubblicazioni-downloads/downloads/?search=Release&c=7&c=87" target="_blank">download di pfadi.swiss</a>.</p>
-


### PR DESCRIPTION
Release-Notes Archiv Information wurde entfernt, weil auf pfadi.swiss keine alten Release-Notes mehr vorhanden sind. Diese sind nun nur noch auf Sharepoint abgelegt.