### PR TITLE
Add Joomla! OAuth plugin docs

### DIFF
--- a/_articles/de/Zusatzfunktionen/Schnittstellen via OAuth.md
+++ b/_articles/de/Zusatzfunktionen/Schnittstellen via OAuth.md
@@ -7,16 +7,22 @@ categories: 3_Zusatzfunktionen
 cat_sort: C
 relevance: Webmaster
 lang: de
-date: 01.01.2022
+date: 24.03.2025
 ---
 
-Die MiData ist ebenfalls ist ein OAuth 2.0 Anbieter, das heisst dass eine externe Applikation Benutzer via MiData authentifizieren kann. Du kennst dieses Prinzip vielleicht bereits, wenn du einmal "Anmelden mit Facebook" oder "Anmelden mit Google" verwendet hast. Die externe Applikation kann danach Informationen über den Benutzer aus der MiData abfragen wenn der Benutzer dies selber freigibt. Die OAuth-Anmeldung ermöglicht es auch, dass die externe Applikation die JSONSchnittstellen im Namen des Users nutzen kann. Die Applikation hat dabei dieselben Berechtigungen wie der Benutzer. 
+Die MiData kann als Authentifizierungs-Dienst benutzt werden. Das heisst man die MiData benutzen, um sich bei einer externen Applikation authentifizieren zu lassen. Dabei implementiert die MiData das [OAuth 2.0](https://oauth.net/2/) Protokoll.
+Das gleiche Prinzip kennst du vielleicht bereits, wenn du einmal "Anmelden mit Facebook" oder "Anmelden mit Google" verwendet hast. Die externe Applikation kann damit Informationen über den Benutzer aus der MiData abfragen wenn der Benutzer dies selber freigibt. Die OAuth-Anmeldung ermöglicht es auch, dass die externe Applikation die JSONSchnittstellen im Namen des Users nutzen kann. Die Applikation hat dabei dieselben Berechtigungen wie der Benutzer.
 
-* [Spezifikation (Englisch)](https://github.com/hitobito/hitobito/blob/master/doc/developer/people/oauth.md)
+## Für Entwickler
+Falls du Entwickler einer externen Applikation bist, welche die MiData als Authentifizierungs-Dienst benutzen möchte, dann findest du hier die Spezifikation der OAuth-API von Hitobito. Hitobito ist der Name der Applikation, welche wir in der Pfadi MiData nennen.
+* [OAuth Spezifikation](https://github.com/hitobito/hitobito/blob/master/doc/developer/people/oauth.md)
 
-Wenn du die MiData als OAuth-Provider für eine deiner Applikationen verwenden willst, musst du den OAuth-Antrag ausfüllen. Der IT-Support der PBS wird dir einen Zugang auf das Produktivsystem vergeben, insofern alle Vorbedingungen erfüllt sind: 
+## Für Admins
+Wenn du die MiData als OAuth-Provider für deiner Applikationen verwenden willst, muss der IT-Support der PBS deine Applikation in MiData registrieren. Fülle dazu den OAuth-Antrag für deine Applikation aus: 
 * [Antrag OAuth Applikation](https://forms.office.com/Pages/ResponsePage.aspx?id=iq6Fcs2Xq0m9ordFTZ0Fa8gnQG-i3p9KkbcKGL9nFhtUMEpMQkYwMzQxNUVEWEIxRTNWTDhPMDVEMS4u&wdLOR=c1CBB434D-BD2A-4C4E-A417-6F0DDA2C01C8)
 
-### Spezifische Anleitungen
-* [Wordpress OAuth Anleitung](https://pfadi.swiss/de/publikationen-downloads/downloads/detail/817/wordpress-oauth-anleitung/)
-* [Nextcloud OAuth Anleitung](https://pfadi.swiss/de/publikationen-downloads/downloads/detail/889/nextcloud-oauth-anleitung/)
+### Verfügbare OAuth Plugins
+Für einige Applikationen existieren Plugins, welche die Implementierung des Logins via OAuth-API für dich machen. Folgend die Anleitungen, wie diese Plugins installiert und eingerichtet werden müssen:
+* [Joomla! OAuth Plugin](https://tech.spuur.ch/files/pdf/joomla-oauth-anleitung.pdf)
+* [WordPress OAuth Plugin](https://pfadi.swiss/de/publikationen-downloads/downloads/detail/817/wordpress-oauth-anleitung/)
+* [Nextcloud OAuth Plugin](https://pfadi.swiss/de/publikationen-downloads/downloads/detail/889/nextcloud-oauth-anleitung/)

--- a/_articles/fr/Zusatzfunktionen/Schnittstellen via OAuth.md
+++ b/_articles/fr/Zusatzfunktionen/Schnittstellen via OAuth.md
@@ -16,5 +16,6 @@ Si tu veux utiliser MiData comme fournisseur OAuth pour l'une de tes application
 * [demande d'application OAuth](https://forms.office.com/Pages/ResponsePage.aspx?id=iq6Fcs2Xq0m9ordFTZ0Fa8gnQG-i3p9KkbcKGL9nFhtUMEpMQkYwMzQxNUVEWEIxRTNWTDhPMDVEMS4u&wdLOR=c1CBB434D-BD2A-4C4E-A417-6F0DDA2C01C8)
 
 ### Instructions spécifiques
-* [Instructions Wordpress OAuth](https://pfadi.swiss/fr/publications-telechargements/downloads/detail/817/wordpress-oauth-instructions/)
+* [Instructions Joomla! OAuth](https://tech.spuur.ch/files/pdf/joomla-oauth-anleitung.pdf)
+* [Instructions WordPress OAuth](https://pfadi.swiss/fr/publications-telechargements/downloads/detail/817/wordpress-oauth-instructions/)
 * [Instructions Nextcloud OAuth](https://pfadi.swiss/fr/publications-telechargements/downloads/detail/889/instructions-nextcloud-oauth/)

--- a/_articles/it/Zusatzfunktionen/Schnittstellen via OAuth.md
+++ b/_articles/it/Zusatzfunktionen/Schnittstellen via OAuth.md
@@ -18,5 +18,6 @@ Se vuoi utilizzare MiData come provider OAuth per una delle tue applicazioni, de
 * [Applicazione OAuth](https://forms.office.com/Pages/ResponsePage.aspx?id=iq6Fcs2Xq0m9ordFTZ0Fa8gnQG-i3p9KkbcKGL9nFhtUMEpMQkYwMzQxNUVEWEIxRTNWTDhPMDVEMS4u&wdLOR=c1CBB434D-BD2A-4C4E-A417-6F0DDA2C01C8)
 
 ### Istruzioni specifiche
+* [Istruzioni Joomla! OAuth](https://tech.spuur.ch/files/pdf/joomla-oauth-anleitung.pdf)
 * [Istruzioni Wordpress OAuth](https://pfadi.swiss/it/pubblicazioni-downloads/downloads/detail/817/wordpress-oauth-istruzioni/)
-* [Instructions Nextcloud OAuth](https://pfadi.swiss/it/pubblicazioni-downloads/downloads/detail/889/istruzioni-nextcloud-oauth/)
+* [Istruzioni Nextcloud OAuth](https://pfadi.swiss/it/pubblicazioni-downloads/downloads/detail/889/istruzioni-nextcloud-oauth/)

--- a/_faqs/de/Wie kann ich mein Joomla verbinden.md
+++ b/_faqs/de/Wie kann ich mein Joomla verbinden.md
@@ -1,0 +1,8 @@
+---
+title: Wie kann ich meine Joomla! Webseite via OAuth verbinden? 
+slug: joomla
+lang: de
+order: E03
+---
+
+Dafür gibt es eine [Anleitung](https://tech.spuur.ch/files/pdf/joomla-oauth-anleitung.pdf) zum Einrichten. Merci an Schlumpf!

--- a/_faqs/fr/Wie kann ich mein Joomla verbinden.md
+++ b/_faqs/fr/Wie kann ich mein Joomla verbinden.md
@@ -1,0 +1,8 @@
+---
+title: Comment puis-je connecter mon Joomla! via OAuth? 
+slug: joomla
+lang: fr
+order: E03
+---
+
+Pour cela, il y a des [instructions](https://tech.spuur.ch/files/pdf/joomla-oauth-anleitung.pdf) pour la mise en place. Merci à Schlumpf !

--- a/_faqs/it/Wie kann ich mein Joomla verbinden.md
+++ b/_faqs/it/Wie kann ich mein Joomla verbinden.md
@@ -1,0 +1,8 @@
+---
+title: Come posso collegare il mio Joomla! tramite OAuth? 
+slug: joomla
+lang: it
+order: E03
+---
+
+Sono disponibili [istruzioni](https://tech.spuur.ch/files/pdf/joomla-oauth-anleitung.pdf) per l'impostazione. Merci a Schlumpf!


### PR DESCRIPTION
**DE**
Dier PR fügt das OAuth Plugin für Joomla! zur Dokumentation hinzu. Die Anleitung zum OAuth Plugin für Joomla! ist auf der Webseite von mir (Schlumpf, Entwickler des Plugins) gehostet. So kann ich die Anleitung selbständig anpassen und verbessern.

**EN**
This PR adds the OAuth Plugin for Joomla! to the documentation. The manual for the OAuth plugin for Joomla! is hosted on the website of me (Schlumpf, developer of the plugin). This allows me to adapt and improve the manual myself.